### PR TITLE
revise: changes `anyhow` out for `miette`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Revised
+
+- Changes out the `anyhow` error type for `miette`
+  ([#5](https://github.com/stjude-rust-labs/tes/pull/5)).
+
+
 ## 0.3.0 - 01-30-2025
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.87"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f00e1f6e58a40e807377c75c6a7f97bf9044fab57816f2414e6f5f4499d7b8"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "async-trait"
@@ -618,6 +618,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "miette"
+version = "7.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a955165f87b37fd1862df2a59547ac542c77ef6d17c666f619d1ad22dd89484"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "thiserror",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf45bf44ab49be92fd1227a3be6fc6f617f1a337c06af54981048574d8783147"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -869,9 +892,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -1292,9 +1315,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1351,6 +1374,7 @@ dependencies = [
  "anyhow",
  "base64 0.21.7",
  "chrono",
+ "miette",
  "ordered-float",
  "pretty_assertions",
  "reqwest",
@@ -1586,6 +1610,12 @@ checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,11 @@ repository = "https://github.com/stjude-rust-labs/tes"
 rust-version = "1.80.0"
 
 [dependencies]
-anyhow = { version = "1.0.87", optional = true }
+# `anyhow` is required because `reqwest_middleware` uses `anyhow::Result` as one
+# of its return types. The main error crates used within `tes` is `miette`.
+anyhow = { version = "1.0.95", optional = true }
 chrono = { version = "0.4.38", features = ["serde"] }
+miette = { version = "7.5.0", optional = true }
 ordered-float = { version = "4.2.2", features = ["serde"] }
 reqwest = { version = "0.12.7", features = ["json"] }
 reqwest-middleware = "0.3.3"
@@ -29,7 +32,7 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 
 [features]
 default = ["types"]
-client = ["dep:anyhow", "types", "dep:serde_json", "dep:url"]
+client = ["dep:anyhow", "dep:miette", "types", "dep:serde_json", "dep:url"]
 ord = []
 serde = ["dep:serde", "dep:serde_json"]
 types = ["dep:url"]

--- a/examples/service-info.rs
+++ b/examples/service-info.rs
@@ -10,9 +10,10 @@
 //! cargo run --release --features=client,serde --example service-info <URL>
 //! ```
 
-use anyhow::Context;
-use anyhow::Result;
 use base64::prelude::*;
+use miette::Context as _;
+use miette::IntoDiagnostic;
+use miette::Result;
 use tes::v1::client;
 use tracing_subscriber::EnvFilter;
 
@@ -56,6 +57,7 @@ async fn main() -> Result<()> {
         client
             .service_info()
             .await
+            .into_diagnostic()
             .context("getting the service information")?
     );
 

--- a/examples/task-get.rs
+++ b/examples/task-get.rs
@@ -10,9 +10,10 @@
 //! cargo run --release --features=client,serde --example task-submit <URL> <ID>
 //! ```
 
-use anyhow::Context;
-use anyhow::Result;
 use base64::prelude::*;
+use miette::Context as _;
+use miette::IntoDiagnostic;
+use miette::Result;
 use tes::v1::client;
 use tes::v1::client::tasks::View;
 use tracing_subscriber::EnvFilter;
@@ -56,6 +57,7 @@ async fn main() -> Result<()> {
         client
             .get_task(id, View::Full)
             .await
+            .into_diagnostic()
             .context("getting a task")?
     );
 

--- a/examples/task-list-all.rs
+++ b/examples/task-list-all.rs
@@ -10,9 +10,10 @@
 //! cargo run --release --features=client,serde --example task-list-all <URL>
 //! ```
 
-use anyhow::Context;
-use anyhow::Result;
 use base64::prelude::*;
+use miette::Context as _;
+use miette::IntoDiagnostic;
+use miette::Result;
 use tes::v1::client;
 use tes::v1::client::tasks::View;
 use tracing_subscriber::EnvFilter; // Import the Engine trait
@@ -55,6 +56,7 @@ async fn main() -> Result<()> {
         client
             .list_all_tasks(View::Full)
             .await
+            .into_diagnostic()
             .context("listing all tasks")?
     );
 

--- a/examples/task-submit.rs
+++ b/examples/task-submit.rs
@@ -10,9 +10,10 @@
 //! cargo run --release --features=client,serde --example task-submit <URL>
 //! ```
 
-use anyhow::Context;
-use anyhow::Result;
 use base64::prelude::*;
+use miette::Context as _;
+use miette::IntoDiagnostic;
+use miette::Result;
 use tes::v1::client;
 use tes::v1::types::Task;
 use tes::v1::types::task::Executor;
@@ -77,6 +78,7 @@ async fn main() -> Result<()> {
         client
             .create_task(task)
             .await
+            .into_diagnostic()
             .context("submitting a task")?
     );
 

--- a/src/v1/client.rs
+++ b/src/v1/client.rs
@@ -29,7 +29,7 @@ pub enum Error {
     SerdeJSON(serde_json::Error),
 
     /// A middleware error from `reqwest_middleware`.
-    // Note: `reqwest_middleware` stores these as an `anyhow::Error` internally.
+    // Note: `reqwest_middleware` stores these as an [`anyhow::Error`] internally.
     Middlware(anyhow::Error),
 
     /// An error from `reqwest`.

--- a/src/v1/types/responses/service_info.rs
+++ b/src/v1/types/responses/service_info.rs
@@ -220,10 +220,13 @@ mod tests {
         );
         assert_eq!(result.environment.unwrap(), "test");
         assert_eq!(result.version, "1.0.0");
-        assert_eq!(result.storage.unwrap(), vec![
-            "file:///path/to/local/funnel-storage",
-            "s3://ohsu-compbio-funnel/storage"
-        ]);
+        assert_eq!(
+            result.storage.unwrap(),
+            vec![
+                "file:///path/to/local/funnel-storage",
+                "s3://ohsu-compbio-funnel/storage"
+            ]
+        );
     }
 
     #[cfg(feature = "serde")]


### PR DESCRIPTION
Converts the errors used internally from `anyhow` to `miette`.

This doesn't affect much except the examples, but I felt it was most consistent to use `miette` since we've switched to using it in our other projects.

Notably, `reqwest_middleware` still uses `anyhow`, so it's kept around as a dependency.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [ ] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
