### PR TITLE
revise: removes `ordered_float` from the `f64` fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Changes out the `anyhow` error type for `miette`
   ([#5](https://github.com/stjude-rust-labs/tes/pull/5)).
+- Removes the `Eq` and `Ord` trait from types containing a `f64` via removal of
+  `ordered_float` ([#6](https://github.com/stjude-rust-labs/tes/pull/6)).
 
 
 ## 0.3.0 - 01-30-2025

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,17 +763,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordered-float"
-version = "4.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a91171844676f8c7990ce64959210cd2eaef32c2612c50f9fae9f8aaa6065a6"
-dependencies = [
- "num-traits",
- "rand",
- "serde",
-]
-
-[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -917,7 +906,6 @@ dependencies = [
  "libc",
  "rand_chacha",
  "rand_core",
- "serde",
 ]
 
 [[package]]
@@ -937,7 +925,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
- "serde",
 ]
 
 [[package]]
@@ -1375,7 +1362,6 @@ dependencies = [
  "base64 0.21.7",
  "chrono",
  "miette",
- "ordered-float",
  "pretty_assertions",
  "reqwest",
  "reqwest-middleware",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ rust-version = "1.80.0"
 anyhow = { version = "1.0.95", optional = true }
 chrono = { version = "0.4.38", features = ["serde"] }
 miette = { version = "7.5.0", optional = true }
-ordered-float = { version = "4.2.2", features = ["serde"] }
 reqwest = { version = "0.12.7", features = ["json"] }
 reqwest-middleware = "0.3.3"
 reqwest-retry = "0.6.1"

--- a/src/v1/types/responses/task.rs
+++ b/src/v1/types/responses/task.rs
@@ -34,10 +34,10 @@ pub struct MinimalTask {
 }
 
 /// A generalized response for getting tasks with the `view` parameter.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(untagged))]
-#[cfg_attr(feature = "ord", derive(Ord, PartialOrd))]
+#[cfg_attr(feature = "ord", derive(PartialOrd))]
 pub enum Response {
     /// A response for when `?view=MINIMAL` in a task endpoint.
     Minimal(MinimalTask),

--- a/src/v1/types/task.rs
+++ b/src/v1/types/task.rs
@@ -7,7 +7,6 @@ use std::collections::HashMap;
 
 use chrono::DateTime;
 use chrono::Utc;
-use ordered_float::OrderedFloat;
 
 pub mod executor;
 pub mod file;
@@ -115,9 +114,9 @@ pub struct Output {
 }
 
 /// Requested resources for a TES task.
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "ord", derive(Ord, PartialOrd))]
+#[cfg_attr(feature = "ord", derive(PartialOrd))]
 pub struct Resources {
     /// The number of CPU cores.
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
@@ -129,11 +128,11 @@ pub struct Resources {
 
     /// The amount of RAM (in gigabytes).
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    pub ram_gb: Option<OrderedFloat<f64>>,
+    pub ram_gb: Option<f64>,
 
     /// The amount of disk space (in gigabytes).
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    pub disk_gb: Option<OrderedFloat<f64>>,
+    pub disk_gb: Option<f64>,
 
     /// The zones.
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
@@ -180,9 +179,9 @@ pub struct TaskLog {
 }
 
 /// A task.
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "ord", derive(Ord, PartialOrd))]
+#[cfg_attr(feature = "ord", derive(PartialOrd))]
 pub struct Task {
     /// The ID.
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]


### PR DESCRIPTION
Upon a closer look, [OpenAPI `double`s](https://swagger.io/docs/specification/v3_0/data-models/data-types/#numbers) don't have a strict definition of what they conform to, so I assume it's going to be IEEE-754. As such, the behavior of Rust to implement the `PartialEq`/`PartialOrd` without `Eq`/`Ord` should carry through here. Indeed, I see no evidence that something like `NaN == NaN` should hold.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
