### PR TITLE
chore: bump dependencies to latest.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Updated dependencies to latest to remove dependency on unmaintained crate ([#7](https://github.com/stjude-rust-labs/tes/pull/7)).
+
 ## 0.4.1 - 02-21-2025
 
 ### Revised

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,22 +12,22 @@ rust-version = "1.80.0"
 [dependencies]
 # `anyhow` is required because `reqwest_middleware` uses `anyhow::Result` as one
 # of its return types. The main error crates used within `tes` is `miette`.
-anyhow = { version = "1.0.95", optional = true }
-chrono = { version = "0.4.38", features = ["serde"] }
+anyhow = { version = "1.0.96", optional = true }
+chrono = { version = "0.4.39", features = ["serde"] }
 miette = { version = "7.5.0", optional = true }
-reqwest = { version = "0.12.7", features = ["json"] }
-reqwest-middleware = "0.3.3"
-reqwest-retry = "0.6.1"
-serde = { version = "1.0.209", features = ["derive"], optional = true }
-serde_json = { version = "1.0.128", optional = true }
-tokio = { version = "1.40.0", features = ["full", "time"] }
-tracing = "0.1.40"
-url = { version = "2.5.2", features = ["serde"], optional = true }
-base64 = "0.21"
+reqwest = { version = "0.12.12", features = ["json"] }
+reqwest-middleware = "0.4.0"
+reqwest-retry = "0.7.0"
+serde = { version = "1.0.218", features = ["derive"], optional = true }
+serde_json = { version = "1.0.139", optional = true }
+tokio = { version = "1.43.0", features = ["full", "time"] }
+tracing = "0.1.41"
+url = { version = "2.5.4", features = ["serde"], optional = true }
+base64 = "0.22"
 
 [dev-dependencies]
-pretty_assertions = "1.4.0"
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+pretty_assertions = "1.4.1"
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 
 [features]
 default = ["types"]


### PR DESCRIPTION
This PR bumps the dependencies of the `tes` crate to their latest versions.

More importantly, it removes a transitive dependency on the `instant` crate which is no longer being maintained.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
