### PR TITLE
fix: add missing `ignore_error` to `Executor`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added missing `ignore_error` field to `Executor` (#[10](https://github.com/stjude-rust-labs/tes/pull/10)).
+
 ## 0.5.0 - 02-21-2025
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,20 +7,20 @@ authors = ["The St. Jude Rust Labs developers"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/stjude-rust-labs/tes"
 repository = "https://github.com/stjude-rust-labs/tes"
-rust-version = "1.80.0"
+rust-version = "1.81.0"
 
 [dependencies]
 # `anyhow` is required because `reqwest_middleware` uses `anyhow::Result` as one
 # of its return types. The main error crates used within `tes` is `miette`.
-anyhow = { version = "1.0.96", optional = true }
-chrono = { version = "0.4.39", features = ["serde"] }
+anyhow = { version = "1.0.98", optional = true }
+chrono = { version = "0.4.40", features = ["serde"] }
 miette = { version = "7.5.0", optional = true }
-reqwest = { version = "0.12.12", features = ["json"] }
-reqwest-middleware = "0.4.0"
+reqwest = { version = "0.12.15", features = ["json"] }
+reqwest-middleware = "0.4.2"
 reqwest-retry = "0.7.0"
-serde = { version = "1.0.218", features = ["derive"], optional = true }
-serde_json = { version = "1.0.139", optional = true }
-tokio = { version = "1.43.0", features = ["full", "time"] }
+serde = { version = "1.0.219", features = ["derive"], optional = true }
+serde_json = { version = "1.0.140", optional = true }
+tokio = { version = "1.44.2", features = ["full", "time"] }
 tracing = "0.1.41"
 url = { version = "2.5.4", features = ["serde"], optional = true }
 base64 = "0.22"

--- a/src/v1/types/task/executor.rs
+++ b/src/v1/types/task/executor.rs
@@ -41,6 +41,13 @@ pub struct Executor {
     /// The environment variables.
     #[cfg(feature = "ord")]
     pub env: Option<BTreeMap<String, String>>,
+
+    /// Default behavior of running an array of executors is that execution
+    /// stops on the first error.
+    ///
+    /// If `ignore_error` is `true`, then the runner will record error exit
+    /// codes, but will continue on to the next executor.
+    pub ignore_error: Option<bool>,
 }
 
 /// A log for an [`Executor`].


### PR DESCRIPTION
This commit adds the missing `ignore_error` field to `Executor`.

Fixes #9.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
