### PR TITLE
fix: update the `State` enum to match the TES API.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added missing `ignore_error` field to `Executor` (#[10](https://github.com/stjude-rust-labs/tes/pull/10)).
+- Added missing `State` enum variants ([#11](https://github.com/stjude-rust-labs/tes/pull/11)).
+- Added missing `ignore_error` field to `Executor` ([#10](https://github.com/stjude-rust-labs/tes/pull/10)).
 
 ## 0.5.0 - 02-21-2025
 


### PR DESCRIPTION
The `Canceling` and `Preempted` states were missing.

Additionally, this changes the doc comments for the enum variants to match the TES API documentation.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
