### PR TITLE
feat: use `thiserror` for error types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Added
+### Changed
 
 - Added `thiserror` dependency for custom error types ([#18](https://github.com/stjude-rust-labs/tes/pull/18)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added `thiserror` dependency for custom error types ([#18](https://github.com/stjude-rust-labs/tes/pull/18)).
+
 ## 0.7.0 - 05-20-2025
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ reqwest-retry = "0.7.0"
 serde = { version = "1.0.219", features = ["derive"], optional = true }
 serde_json = { version = "1.0.140" }
 serde_url_params = { version = "0.2.1", optional = true }
+thiserror = "2.0.12"
 tokio = { version = "1.44.2", features = ["full", "time"] }
 tracing = "0.1.41"
 url = { version = "2.5.4", features = ["serde"], optional = true }

--- a/src/v1/types/responses/service_info/builder.rs
+++ b/src/v1/types/responses/service_info/builder.rs
@@ -14,24 +14,12 @@ use crate::v1::types::responses::service_info::TES_VERSION;
 pub const DEFAULT_GROUP: &str = "org.ga4gh";
 
 /// An error related to a [`Builder`].
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, thiserror::Error)]
 pub enum Error {
     /// A required value was missing for a builder field.
+    #[error("missing required field `{0}`")]
     Missing(&'static str),
 }
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Error::Missing(field) => write!(
-                f,
-                "missing required value for '{field}' in a service information builder"
-            ),
-        }
-    }
-}
-
-impl std::error::Error for Error {}
 
 /// A [`Result`](std::result::Result) with an [`Error`].
 pub type Result<T> = std::result::Result<T, Error>;


### PR DESCRIPTION
This also removes the unnecessary prefixes from the custom error display implementations.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
